### PR TITLE
Remove Hardcoded URI from MQTTSN Setup

### DIFF
--- a/packages/outdoor-location-engine/src/mqtt/mqttsn.c
+++ b/packages/outdoor-location-engine/src/mqtt/mqttsn.c
@@ -60,7 +60,7 @@ int mqttsn_initialize() {
 	int err;
 	struct sockaddr_in gateway = {0};
 
-	char *ip_str = getIpAddressFromHostname("api.findmycat.io");
+	char *ip_str = getIpAddressFromHostname(CONFIG_FINDMYCAT_CLOUD_HOSTNAME);
 	LOG_DBG("Parsing MQTT host IP ", ip_str);
 	gateway.sin_family = AF_INET;
 	gateway.sin_port = htons(CONFIG_MQTT_SN_GATEWAY_PORT);


### PR DESCRIPTION
This makes use of the prj.conf to set the API URI instead of the hardcoded value.